### PR TITLE
Fix booth build+upload on Linux

### DIFF
--- a/Packages/com.pjkt.sdk/Editor/Systems/PjktBuildSize.cs
+++ b/Packages/com.pjkt.sdk/Editor/Systems/PjktBuildSize.cs
@@ -25,16 +25,16 @@ namespace PJKT.SDK2
                 Debug.LogError("<color=#FFBB00><b>PJKT SDK:</b></color> Select an object with a booth descriptor");
                 return;
             }
-            
+
             GameObject obj = Selection.activeObject as GameObject;
             BoothDescriptor booth = obj.GetComponent<BoothDescriptor>();
-            
+
             if (booth == null)
             {
                 Debug.LogError("<color=#FFBB00><b>PJKT SDK:</b></color> Selected object does not have a booth descriptor");
                 return;
             }
-            
+
             long size = AssessBuildSize(booth);
 
             if (size == -1)
@@ -45,44 +45,48 @@ namespace PJKT.SDK2
 
             Debug.Log("<color=#FFBB00><b>PJKT SDK:</b></color> Build size: " + BoothValidator.FormatSize(size));
         }
-        
+
         //plan is to create a new temporary scene, copy the booth to it and build that scene into an asset bundle
         public static long AssessBuildSize(BoothDescriptor booth)
         {
             //prolly need to do some sort of editor lock or progress bar here
             char[] invalidChars = Path.GetInvalidFileNameChars();
-            string cleanCommunityName = string.Join("_",booth.currentCommunity.Split(invalidChars, StringSplitOptions.RemoveEmptyEntries)).TrimEnd('.');
-            
-            string tempFilePath = Path.GetTempPath() + "PjktSdk\\";
-            string prefabPath = "Assets/PjktTemp/" + cleanCommunityName + "_BuildSizeTemp.prefab";
-            
+            string cleanCommunityName = string.Join("_", booth.currentCommunity.Split(invalidChars, StringSplitOptions.RemoveEmptyEntries)).TrimEnd('.');
+
+            string tempPath = Path.Combine(Path.GetTempPath(), "PjktSdk");
+            string assetBundleName = $"{cleanCommunityName.ToLower()}_buildsizetemp"; // lowercase due to BuildAssetBundles producing only lowercase filenames
+            string assetBundlePath = Path.Combine(tempPath, assetBundleName);
+
+            string prefabBuildPath = Path.Combine("Assets", "PjktTemp");
+            string prefabPath = Path.Combine(prefabBuildPath, assetBundleName + ".prefab");
+
             AssetBundleManifest manifest = null;
-            
+
             try
             {
-                if (!Directory.Exists("Assets/PjktTemp/")) Directory.CreateDirectory("Assets/PjktTemp/");
-                if (!Directory.Exists(tempFilePath)) Directory.CreateDirectory(tempFilePath);
-                
+                if (!Directory.Exists(prefabBuildPath)) Directory.CreateDirectory(prefabBuildPath);
+                if (!Directory.Exists(tempPath)) Directory.CreateDirectory(tempPath);
+
                 //make a copy before anything
                 GameObject boothClone = GameObject.Instantiate(booth.gameObject);
-                
+
                 //if the booth clone has any material swappers remove them
                 PjktMaterialSwapper[] swappers = boothClone.GetComponentsInChildren<PjktMaterialSwapper>(true);
                 foreach (PjktMaterialSwapper swap in swappers)
                 {
                     GameObject.DestroyImmediate(swap);
                 }
-                
+
                 PrefabUtility.SaveAsPrefabAsset(boothClone, prefabPath);
                 GameObject.DestroyImmediate(boothClone);
 
                 AssetBundleBuild build = new AssetBundleBuild
                 {
-                    assetBundleName = $"{cleanCommunityName}_BuildSizeTemp",
+                    assetBundleName = assetBundleName,
                     assetNames = new[] { prefabPath }
                 };
 
-                manifest = BuildPipeline.BuildAssetBundles(tempFilePath, new[] { build }, BuildAssetBundleOptions.None, BuildTarget.StandaloneWindows64); //figure out android later
+                manifest = BuildPipeline.BuildAssetBundles(tempPath, new[] { build }, BuildAssetBundleOptions.None, BuildTarget.StandaloneWindows64); //figure out android later
             }
             catch (Exception e)
             {
@@ -90,18 +94,17 @@ namespace PJKT.SDK2
             }
 
             if (manifest == null) return -1;
-            
-            if (!File.Exists(tempFilePath + $"{cleanCommunityName}_BuildSizeTemp")) return -1;
-                
-            FileInfo fileInfo = new FileInfo(tempFilePath + $"{cleanCommunityName}_BuildSizeTemp");
+
+            if (!File.Exists(assetBundlePath)) return -1;
+
+            FileInfo fileInfo = new FileInfo(assetBundlePath);
             long builtSize = fileInfo.Length;
-            
+
             //get rid of temp prefab
             if (File.Exists(prefabPath)) File.Delete(prefabPath);
             if (File.Exists(prefabPath + ".meta")) File.Delete(prefabPath + ".meta");
 
             AssetDatabase.Refresh();
-            
             return builtSize;
         }
 #endif

--- a/Packages/com.pjkt.sdk/Editor/Systems/PjktFileExporter.cs
+++ b/Packages/com.pjkt.sdk/Editor/Systems/PjktFileExporter.cs
@@ -16,11 +16,11 @@ namespace PJKT.SDK2
     public class PjktFileExporter //: IDisposable
     {
 #if UNITY_EDITOR
-        
+
         //[MenuItem("PJKT/TestExporter")]
         public static void Test()
         {
-            if(Selection.activeObject is GameObject)
+            if (Selection.activeObject is GameObject)
             {
                 GameObject booth = Selection.activeObject as GameObject;
                 PjktFileExporter exporter = new PjktFileExporter("test");
@@ -28,21 +28,23 @@ namespace PJKT.SDK2
             }
         }
 
+        public readonly string PrefabDirectory;
         public readonly string TempDirectory;
         public readonly string CommunityName;
         public readonly string ExportPath;
-        
-        public PjktFileExporter(string  communityName, string exportPath = "")
+
+        public PjktFileExporter(string communityName, string exportPath = "")
         {
             //sanitise community name. disallow < > : " / \ | ? *
             char[] invalidChars = Path.GetInvalidFileNameChars();
             string cleanName = string.Join("_", communityName.Split(invalidChars, StringSplitOptions.RemoveEmptyEntries)).TrimEnd('.');
-            
+
             CommunityName = cleanName;
-            TempDirectory = Path.GetTempPath() + "PjktSdk\\" + CommunityName;
+            TempDirectory = Path.Combine(Path.GetTempPath(), "PjktSdk", CommunityName);
             ExportPath = exportPath;
+            PrefabDirectory = Path.Combine("Assets", "PjktTemp");
         }
-        
+
         public string CreateBoothfile(GameObject booth)
         {
             if (booth == null)
@@ -50,79 +52,79 @@ namespace PJKT.SDK2
                 Debug.LogError("Cannot create booth file from null object");
                 return string.Empty;
             }
-            
+
             //create prefab of the booth first
             string boothName = CommunityName + "_" + PjktEventManager.SelectedProjekt.name;
-            string path = "Assets/PjktTemp/" + boothName + ".prefab";
-            
+            string prefabPath = Path.Combine(PrefabDirectory, boothName + ".prefab");
+
             //check if the directory exists
-            if (!Directory.Exists("Assets/PjktTemp"))
+            if (!Directory.Exists(PrefabDirectory))
             {
-                Directory.CreateDirectory("Assets/PjktTemp");
+                Directory.CreateDirectory(PrefabDirectory);
             }
-            
+
             //create temp directories for the booth files
-            CreateTempfolders(CommunityName);
-            
+            CreateTempfolders();
+
             //using a duplicate of the booth so we can zero out the xz pos and unlink any other prefabs
             GameObject tempBooth = GameObject.Instantiate(booth, new Vector3(0, booth.transform.position.y, 0), booth.transform.rotation);
             FindAndUnpackPrefabInstances(tempBooth);
-            
+
             //create the prefab
-            PrefabUtility.SaveAsPrefabAsset(tempBooth, path);
+            PrefabUtility.SaveAsPrefabAsset(tempBooth, prefabPath);
 
             //get all dependedncies of the prefab
-            string[] dependencies = AssetDatabase.GetDependencies(path);
-            
+            string[] dependencies = AssetDatabase.GetDependencies(prefabPath);
+
             //sorts duplicated of the files into temp appdata folder
             if (!SortFiles(dependencies))
             {
                 PjktSdkWindow.Notify("Booth upload canceled", BoothErrorType.Warning);
                 //cleanup the prefab
                 GameObject.DestroyImmediate(tempBooth);
-                if (File.Exists(path)) File.Delete(path);
-                if (File.Exists(path +".meta" )) File.Delete(path + ".meta");
+                if (File.Exists(prefabPath)) File.Delete(prefabPath);
+                if (File.Exists(prefabPath + ".meta")) File.Delete(prefabPath + ".meta");
                 return string.Empty;
             }
-            
+
             //do community and booth info json here
-            CommunityInfo communityInfo = new  CommunityInfo();
+            CommunityInfo communityInfo = new CommunityInfo();
             communityInfo.Id = Authentication.ActiveUser.GetCommunityId(CommunityName);
             communityInfo.CommunityName = CommunityName;
             communityInfo.CommunityDescription = ""; //cant get this yet. waiting on backend
             communityInfo.LogoUrl = ""; //cant get this yet. waiting on backend
             communityInfo.GroupID = booth.GetComponent<BoothDescriptor>().GroupID;
-            
-            SdkBoothInfo sdkBoothInfo = new  SdkBoothInfo();
+
+            SdkBoothInfo sdkBoothInfo = new SdkBoothInfo();
             sdkBoothInfo.BoothPrefabName = booth.name;
-            List<string> boothStats = new  List<string>();
+            List<string> boothStats = new List<string>();
             foreach (BoothStats stat in BoothValidator.Report.Stats)
             {
                 boothStats.Add(stat.ToString());
             }
             sdkBoothInfo.BoothStats = boothStats.ToArray();
-            
-            BoothMetadata metadata = new  BoothMetadata();
+
+            BoothMetadata metadata = new BoothMetadata();
             metadata.boothType = BoothType.SdkBooth;
             metadata.communityInfo = communityInfo;
             metadata.sdkBoothInfo = sdkBoothInfo;
             metadata.EventName = PjktEventManager.SelectedProjekt.name;
             metadata.BoothUploadDate = DateTime.Now;
             metadata.BoothUploaderUsername = Authentication.ActiveUser.user.username;
-            
+
             string json = JsonUtility.ToJson(metadata, true);
-            File.WriteAllText($"{TempDirectory}\\boothInfo {CommunityName} - {metadata.EventName}.json", json);
-            
+            File.WriteAllText(Path.Combine(TempDirectory, $"boothInfo {CommunityName} - {metadata.EventName}.json"), json);
+
             //now zip it up
-            string zipPath = string.IsNullOrEmpty(ExportPath)? "Assets/PjktTemp/" + boothName + ".zip" : ExportPath;
+            string zipPath = string.IsNullOrEmpty(ExportPath) ? Path.Combine(PrefabDirectory, boothName + ".zip") : ExportPath;
             if (File.Exists(zipPath)) File.Delete(zipPath);
             ZipFile.CreateFromDirectory(TempDirectory, zipPath);
-            
+
             //cleanup the prefab
             GameObject.DestroyImmediate(tempBooth);
-            
-            if (File.Exists(path)) File.Delete(path);
-            if (File.Exists(path +".meta" )) File.Delete(path + ".meta");
+
+            if (File.Exists(prefabPath)) File.Delete(prefabPath);
+            if (File.Exists(prefabPath + ".meta")) File.Delete(prefabPath + ".meta");
 
             if (File.Exists(zipPath)) return zipPath;
             return string.Empty;
@@ -137,7 +139,7 @@ namespace PJKT.SDK2
                 {
                     PrefabUtility.UnpackPrefabInstance(booth, PrefabUnpackMode.Completely, InteractionMode.UserAction);
                 }
-                
+
                 //check child objects
                 if (PrefabUtility.IsPartOfPrefabInstance(child.gameObject))
                 {
@@ -145,9 +147,11 @@ namespace PJKT.SDK2
                 }
             }
         }
-        
-        //uses %localappdata%\Temp\PjktSdk\communityName to store the files
-        private void CreateTempfolders(string CommunityName)
+
+        // creates directory structure in the temporary folder
+        // Windows: %LocalAppdata%\Temp\PjktSdk\CommunityName
+        // Linux: /tmp/PjktSdk/CommunityName
+        private void CreateTempfolders()
         {
             if (!Directory.Exists(TempDirectory))
             {
@@ -159,7 +163,7 @@ namespace PJKT.SDK2
                 DirectoryInfo di = new DirectoryInfo(TempDirectory);
                 foreach (FileInfo file in di.GetFiles()) file.Delete();
             }
-            
+
             //folders for textures, materials, models, etc
             CreateOrClearFolder("Textures");
             CreateOrClearFolder("Materials");
@@ -170,35 +174,36 @@ namespace PJKT.SDK2
             CreateOrClearFolder("OtherFiles");
         }
 
+        // ensures the target folders exist and are empty
         private void CreateOrClearFolder(string fileType)
         {
-            //if directory already exists then delete files in it
-            if (!Directory.Exists($"{TempDirectory}\\{fileType}"))
+            // if directory already exists then delete files in it
+            if (!Directory.Exists(Path.Combine(TempDirectory, fileType)))
             {
-                Directory.CreateDirectory($"{TempDirectory}\\{fileType}");
+                Directory.CreateDirectory(Path.Combine(TempDirectory, fileType));
             }
             else
             {
-                DirectoryInfo di = new DirectoryInfo($"{TempDirectory}\\{fileType}");
+                DirectoryInfo di = new DirectoryInfo(Path.Combine(TempDirectory, fileType));
                 foreach (FileInfo file in di.GetFiles()) file.Delete();
             }
         }
-        
-        //sorts the files into correct folders in the temp appdata folder
+
+        // sorts the files into correct folders in the temp appdata folder
         private bool SortFiles(string[] files)
         {
             //chat is dir real?
             if (!Directory.Exists(TempDirectory)) throw new Exception("Temp Directory does not exist");
-            
+
             //for each file in the dependencies, get the file type and make a duplicate in the temp folder
             foreach (string file in files)
             {
                 //if the file path starts with packages ignore it
                 if (file.StartsWith("Packages")) continue;
-                
+
                 //if file is a script then skip it
                 if (file.EndsWith(".cs") || file.EndsWith(".cs.meta")) continue;
-                
+
                 //exclude udon program assets
                 if (file.EndsWith(".asset"))
                 {
@@ -206,16 +211,16 @@ namespace PJKT.SDK2
                     string yaml = File.ReadAllText(file);
                     if (yaml.Contains("serializedUdonProgramAsset")) continue;
                 }
-                
+
                 string fileType = GetFileType(file);
                 string fileName = Path.GetFileName(file);
-                string newFilePath = $"{TempDirectory}\\{fileType}\\{fileName}";
-                
+                string newFilePath = Path.Combine(TempDirectory, fileType, fileName);
+
                 //grab its .meta file as well
                 string metaFile = file + ".meta";
-                
+
                 //copy the file to the new location
-                
+
                 //rename if duplicate name
                 if (File.Exists(newFilePath))
                 {
@@ -233,11 +238,11 @@ namespace PJKT.SDK2
                             return false;
                         }
                     }
-                    
+
                     string newFilename = Path.GetFileNameWithoutExtension(newFilePath) + $"_{Guid.NewGuid()}" + Path.GetExtension(newFilePath);
                     newFilePath = $"{TempDirectory}\\{fileType}\\{newFilename}";
                 }
-                
+
                 File.Copy(file, newFilePath);
                 File.Copy(metaFile, newFilePath + ".meta");
             }
@@ -245,7 +250,7 @@ namespace PJKT.SDK2
             return true;
         }
 
-        //figures out what folder the file is supposed to go in
+        // figures out what folder the file is supposed to go in
         private string GetFileType(string file)
         {
             //sort by file extensions, type causes too many issues
@@ -262,13 +267,13 @@ namespace PJKT.SDK2
                     return "Textures";
                 case ".tif":
                     return "Textures";
-                
+
                 //animations
                 case ".anim":
                     return "Animations";
                 case ".controller":
                     return "Animations";
-                
+
                 //audio
                 case ".wav":
                     return "Audio";
@@ -276,25 +281,25 @@ namespace PJKT.SDK2
                     return "Audio";
                 case ".flac":
                     return "Audio";
-                
+
                 //materials
                 case ".mat":
                     return "Materials";
-                
+
                 //shaders
                 case ".shader":
                     return "Shaders";
-                
+
                 //models
                 case ".fbx":
                     return "Models";
                 case ".obj":
                     return "Models";
-                
+
                 //prefabs
                 case ".prefab":
                     return "";
-                
+
                 //everything else
                 default:
                     return "OtherFiles";
@@ -309,9 +314,9 @@ namespace PJKT.SDK2
                 Directory.Delete(TempDirectory, true);
             }
 
-            if (Directory.Exists("Assets/PjktTemp/"))
+            if (Directory.Exists(PrefabDirectory))
             {
-                Directory.Delete("Assets/PjktTemp/", true);
+                Directory.Delete(PrefabDirectory, true);
             }
         }
 #endif


### PR DESCRIPTION
Changes build size test and file exporter to use `Path.Combine` instead of backslash concatenation, plus case sensitivity for built AssetBundle file so they work on Linux