### PR TITLE
Fix PJKT SDK window focusing on domain reload

### DIFF
--- a/Packages/com.pjkt.sdk/Editor/Systems/PjktEventManager.cs
+++ b/Packages/com.pjkt.sdk/Editor/Systems/PjktEventManager.cs
@@ -13,19 +13,19 @@ namespace PJKT.SDK2
     {
         public static Project SelectedProjekt { get; set; }
         public static List<Project> Projekts = new List<Project>();
-        
+
         public static async void GetEvents()
         {
             Projekts.Clear();
 
             string response = await PJKTNet.RequestMessage("/projects");
             if (string.IsNullOrEmpty(response)) return;
-            
+
             //Debug.Log($"events response: \n{response}");
 
             ProjectsData data = JsonUtility.FromJson<ProjectsData>(response);
             Projekts = new List<Project>(data.projects);
-            
+
             //grab the latest event and auto select it
             if (Projekts.Count <= 0) return;
 
@@ -33,9 +33,9 @@ namespace PJKT.SDK2
             Project currentProject = null;
             foreach (var evt in Projekts)
             {
-                DateTime deadline = DateTime.Parse(evt.booth_deadline_date);   
+                DateTime deadline = DateTime.Parse(evt.booth_deadline_date);
                 if (deadline <= latest) continue;
-                
+
                 latest = deadline;
                 currentProject = evt;
             }
@@ -46,7 +46,7 @@ namespace PJKT.SDK2
             Vector3 bounds = new  Vector3(currentProject.booth_requirements.MaxDims[0], currentProject.booth_requirements.MaxDims[1], currentProject.booth_requirements.MaxDims[2]);
             BoothDescriptor._maxBounds = (bounds);
             BoothValidator.Requirements = currentProject.booth_requirements;
-            PjktSdkWindow window = EditorWindow.GetWindow<PjktSdkWindow>();
+            PjktSdkWindow window = EditorWindow.GetWindow<PjktSdkWindow>(title: "PJKT SDK2", focus: false);
             if (window != null) window.SetEvent(currentProject);
         }
     }


### PR DESCRIPTION
`EditorWindow.GetWindow` has a silent side effect of focusing the window unless you explicitly tell it not to. Because it's used in `PjktEventManager::GetEvents`, which is called in [`PjktSdkWindow::OnEnable`](https://github.com/scarletcafe/PJKT-SDK/blob/47303b5113bb031b3ce92822eddd5504e68697f2/Packages/com.pjkt.sdk/Editor/PjktSdkWindow.cs#L56), the PJKT SDK window will always focus on domain reload.

This is most prominently an issue if you do a multiplatform build with the VRCSDK. The VRCSDK changes platforms and continues the build for you, but changing platform reloads the domain, and the VRCSDK won't continue the build until it is visible on screen. That means if you dock the PJKT SDK to the side alongside the VRCSDK (as I do and as is the default behaviour iirc), the PJKT SDK will steal focus on platform change, and the VRCSDK won't continue the build until you manually switch back.

This PR changes the GetWindow call to prevent it taking focus. Because for some reason GetWindow doesn't take `focus` on its own, I've used the overload that sets the title and focus as even if it is changed down the line, the title is always set manually by the SDK window itself upon loading anyway.